### PR TITLE
Added Linux support

### DIFF
--- a/source/derelict/sndfile/sndfile.d
+++ b/source/derelict/sndfile/sndfile.d
@@ -44,6 +44,8 @@ private
 
     static if(Derelict_OS_Windows)
         enum libNames = "libsndfile-1.dll";
+    else static if(Derelict_OS_Linux)
+        enum libNames = "libsndfile.so.1,libsndfile.so";
     else
         static assert(0, "Need to implement libsndfile libNames for this operating system.");
 }


### PR DESCRIPTION
Added libsndfile library names to search for on Linux. Tested on Ubuntu 14.04, where the correct library name is `libsndfile.so.1`.
