### PR TITLE
Added OSX library names.

### DIFF
--- a/source/derelict/sndfile/sndfile.d
+++ b/source/derelict/sndfile/sndfile.d
@@ -46,6 +46,8 @@ private
         enum libNames = "libsndfile-1.dll";
     else static if(Derelict_OS_Linux)
         enum libNames = "libsndfile.so.1,libsndfile.so";
+    else static if(Derelict_OS_Mac)
+        enum libNames = "libsndfile.1.dylib,libsndfile.dylib";
     else
         static assert(0, "Need to implement libsndfile libNames for this operating system.");
 }


### PR DESCRIPTION
Hey there :)

I saw your binding is missing support for OSX, so I fixed it! It now imports without problem on Windows, Linux and OS X.

Tested on both Mac OS X 10.10 and 10.11 with the C library installed from `brew install libsndfile`.

Enjoy!
